### PR TITLE
勤怠エラーチェック機能追加

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,0 +1,16 @@
+# SlackのTokenをそれぞれ設定
+# ローカルで動かす場合はtest用のBOTがいるのでそれを使用すると良い
+# ref : https://api.slack.com/apps/A08F98A9HD4
+
+# OAuth & Permissions の Bot User OAuth Token を設定
+# https://api.slack.com/apps/A08F98A9HD4/oauth?
+export SLACK_BOT_TOKEN=
+
+# Basic Information の App-Level Tokens を設定
+# https://api.slack.com/apps/A08F98A9HD4/general?
+export SLACK_APP_TOKEN=
+
+# KOTはプロキシ経由でないとアクセスできないため、http-proxyの設定が必要
+# ex : export KOT_HTTPS_PROXY=https://{username}:{password}@secure-proxy.lapras.io:20682
+export KOT_HTTPS_PROXY=
+export KOT_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# direnv
+.envrc

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Slash コマンドの登録
 ```
 $ git clone git@github.com:showwin/kintai-paccho.git
 $ cd kintai-paccho
-$ export SLACK_BOT_TOKEN=xoxb-<your-bot-token>  # Slack の Token を設定
-$ export SLACK_APP_TOKEN=xapp-<your-app-level-token>  # Slack の Token を設定
-$ export KOT_TOKEN=xxxxxxxxxxxxxxxx  # King of Time の Token を設定
+
+# 環境変数を設定
+$ cp .envrc.example .envrc
+$ direnv allow
 
 $ poetry install
 $ poetry run python run.py

--- a/components/usecase.py
+++ b/components/usecase.py
@@ -36,17 +36,17 @@ def record_time(record_type: RecordType, employee_key):
 def get_daily_timacard_data(from_date, to_date):
     """
     日別勤怠データを取得する
-    
+
     Args:
         from_date: 取得開始日付（YYYY-MM-DD形式）
         to_date: 取得終了日付（YYYY-MM-DD形式）
-        
+
     Returns:
         辞書型の日別勤怠データ
     """
     requester = KOTRequester()
     uri = f"/daily-workings?&start={from_date}&end={to_date}&additionalFields=currentDateEmployee"
-    
+
     return requester.get(uri)
 
 

--- a/components/usecase.py
+++ b/components/usecase.py
@@ -33,6 +33,26 @@ def record_time(record_type: RecordType, employee_key):
     requester.post("/daily-workings/timerecord/{}".format(employee_key), payload)
 
 
+def get_daily_timacard_data(from_date=None, to_date=None):
+    """
+    日別勤怠データを取得する
+    
+    Args:
+        from_date: 取得開始日付（YYYY-MM-DD形式）。指定がない場合は今日の日付
+        to_date: 取得終了日付（YYYY-MM-DD形式）。指定がない場合はfrom_dateと同じ日付
+        
+    Returns:
+        辞書型の日別勤怠データ
+    """
+    requester = KOTRequester()
+    start_date = from_date if from_date else _get_working_date()
+    end_date = to_date if to_date else start_date
+
+    uri = f"/daily-workings?&start={start_date}&end={end_date}&additionalFields=currentDateEmployee"
+    
+    return requester.get(uri)
+
+
 def _get_working_date():
     """
     return today formatting '%Y-%m-%d'.

--- a/components/usecase.py
+++ b/components/usecase.py
@@ -33,22 +33,19 @@ def record_time(record_type: RecordType, employee_key):
     requester.post("/daily-workings/timerecord/{}".format(employee_key), payload)
 
 
-def get_daily_timacard_data(from_date=None, to_date=None):
+def get_daily_timacard_data(from_date, to_date):
     """
     日別勤怠データを取得する
     
     Args:
-        from_date: 取得開始日付（YYYY-MM-DD形式）。指定がない場合は今日の日付
-        to_date: 取得終了日付（YYYY-MM-DD形式）。指定がない場合はfrom_dateと同じ日付
+        from_date: 取得開始日付（YYYY-MM-DD形式）
+        to_date: 取得終了日付（YYYY-MM-DD形式）
         
     Returns:
         辞書型の日別勤怠データ
     """
     requester = KOTRequester()
-    start_date = from_date if from_date else _get_working_date()
-    end_date = to_date if to_date else start_date
-
-    uri = f"/daily-workings?&start={start_date}&end={end_date}&additionalFields=currentDateEmployee"
+    uri = f"/daily-workings?&start={from_date}&end={to_date}&additionalFields=currentDateEmployee"
     
     return requester.get(uri)
 

--- a/handler/jp/timecard_check.py
+++ b/handler/jp/timecard_check.py
@@ -1,9 +1,11 @@
+from datetime import date, datetime, timedelta
+
+from dateutil.relativedelta import relativedelta
+
 from components.repo import Employee
 from components.requester import KOTException
 from components.typing import SlackRequest
 from components.usecase import get_daily_timacard_data
-from datetime import datetime, timedelta, date
-from dateutil.relativedelta import relativedelta
 
 from .helper import response_configuration_help, response_general_error, response_kot_error
 

--- a/handler/jp/timecard_check.py
+++ b/handler/jp/timecard_check.py
@@ -1,0 +1,91 @@
+from components.repo import Employee
+from components.requester import KOTException
+from components.typing import SlackRequest
+from components.usecase import get_daily_timacard_data
+from datetime import datetime, timedelta, date
+from dateutil.relativedelta import relativedelta
+
+from .helper import response_configuration_help, response_general_error, response_kot_error
+
+
+def announce_timecard_errors(say, request: SlackRequest):
+    """
+    先月1日 ~ 前日までに勤怠エラーがある人をアナウンスする
+    """
+
+    try:
+        # ----------------------------------------
+        # 日付範囲の構築をし、勤怠情報を取得
+        # 取得範囲は「先月1日から前日まで」
+        # ----------------------------------------
+
+        # 先月の1日 ~ 前日の日付文字列を構築
+        first_day_of_last_month_str = (date.today() - relativedelta(months=1)).strftime("%Y-%m-%d")
+        yesterday_str = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+
+        # 勤怠データを取得
+        print(f"date range: {first_day_of_last_month_str} to {yesterday_str}")
+        timecard_data = get_daily_timacard_data(from_date=first_day_of_last_month_str, to_date=yesterday_str)
+        print(f"data count: {len(timecard_data)}")
+
+        # データが空の場合のチェック
+        if len(timecard_data) == 0:
+            say(":den_paccho1: < 勤怠データが見つからなかったよ！")
+            return
+
+        # ----------------------------------------
+        # 勤怠データから通知内容を構築
+        # ----------------------------------------
+
+        # 日付ごとのエラーデータ格納用
+        # 勤怠エラーがある人のデータを日付ごとに格納する
+        # { "2025-02-01": { "code": "0009", "lastName": "山田", "firstName": 伝蔵", "isError": True ....} }
+        error_data = {}
+
+        for daily_data in timecard_data:
+            error_timecard = []
+            for daily_working in daily_data["dailyWorkings"]:
+                if daily_working["isError"] == True:
+                    error_timecard.append(daily_working)
+            
+            if error_timecard:
+                timecard_date = daily_data.get("date", "不明")
+                error_data[timecard_date] = error_timecard
+
+        if not error_data:
+            say(":den_paccho1: < 勤怠エラーの人はいないよ！やったね！")
+            return
+
+        # ----------------------------------------
+        # 通知メッセージ構築 & 送信
+        # ----------------------------------------
+        # メッセージの表示サンプル:
+        # :den_paccho1: < 勤怠エラーがある人をお知らせするよ！
+        #
+        # ■2023-04-01
+        # 0009 山田 伝蔵
+        # 0010 熊本 太郎
+        #
+        # ■2023-04-02
+        # 0100 らぷ らす
+        message = ":den_paccho1: < 勤怠エラーがある人をお知らせするよ！\n\n"
+
+        # 日付順でエラーを表示
+        for day in sorted(error_data.keys()):
+            message += f"■{day}\n"
+            # 従業員番号順でエラー対象者を表示する
+            sorted_workings = sorted(error_data[day], key=lambda w: w.get("currentDateEmployee", {}).get("code", "不明"))
+            for working in sorted_workings:
+                employee = working.get("currentDateEmployee", {})
+                code = employee.get("code", "不明")
+                last_name = employee.get("lastName", "")
+                first_name = employee.get("firstName", "")
+                message += f"{code} {last_name} {first_name}\n"
+            message += "\n"
+
+        say(message)
+
+    except KOTException as e:
+        response_kot_error(say, e)
+    except Exception as e:
+        response_general_error(say, e) 

--- a/handler/jp/timecard_check.py
+++ b/handler/jp/timecard_check.py
@@ -47,7 +47,7 @@ def announce_timecard_errors(say, request: SlackRequest):
             for daily_working in daily_data["dailyWorkings"]:
                 if daily_working["isError"] == True:
                     error_timecard.append(daily_working)
-            
+
             if error_timecard:
                 timecard_date = daily_data.get("date", "不明")
                 error_data[timecard_date] = error_timecard
@@ -88,4 +88,4 @@ def announce_timecard_errors(say, request: SlackRequest):
     except KOTException as e:
         response_kot_error(say, e)
     except Exception as e:
-        response_general_error(say, e) 
+        response_general_error(say, e)

--- a/run.py
+++ b/run.py
@@ -21,16 +21,11 @@ def create_app(is_test=False):
         token = os.environ["SLACK_BOT_TOKEN"]
         app = App(token=token)
 
-
     @app.event("app_mention")
     def handle_app_mention_events(event, say):
         # 勤怠エラーがある人をアナウンスする
         if "勤怠エラー" in event["text"].lower():
-            request = SlackRequest(
-                channel_id=event["channel"],
-                user_id=event["user"],
-                text=event["text"]
-            )
+            request = SlackRequest(channel_id=event["channel"], user_id=event["user"], text=event["text"])
             announce_timecard_errors(say, request)
 
     # record timestamp

--- a/run.py
+++ b/run.py
@@ -9,8 +9,8 @@ from slack_sdk import WebClient
 from components.typing import SlackRequest
 from handler.jp.configuration import register_employee_code
 from handler.jp.extra import be_shy, how_to_use, i_am_not_alexa, i_am_not_siri
-from handler.jp.timecard_check import announce_timecard_errors
 from handler.jp.time_recorder import record_clock_in, record_clock_out, record_end_break, record_start_break
+from handler.jp.timecard_check import announce_timecard_errors
 
 
 def create_app(is_test=False):

--- a/run.py
+++ b/run.py
@@ -9,6 +9,7 @@ from slack_sdk import WebClient
 from components.typing import SlackRequest
 from handler.jp.configuration import register_employee_code
 from handler.jp.extra import be_shy, how_to_use, i_am_not_alexa, i_am_not_siri
+from handler.jp.timecard_check import announce_timecard_errors
 from handler.jp.time_recorder import record_clock_in, record_clock_out, record_end_break, record_start_break
 
 
@@ -19,6 +20,18 @@ def create_app(is_test=False):
     else:
         token = os.environ["SLACK_BOT_TOKEN"]
         app = App(token=token)
+
+
+    @app.event("app_mention")
+    def handle_app_mention_events(event, say):
+        # 勤怠エラーがある人をアナウンスする
+        if "勤怠エラー" in event["text"].lower():
+            request = SlackRequest(
+                channel_id=event["channel"],
+                user_id=event["user"],
+                text=event["text"]
+            )
+            announce_timecard_errors(say, request)
 
     # record timestamp
     @app.message(re.compile("^おはー[！？!?]*$"))

--- a/test/components/test_usecase.py
+++ b/test/components/test_usecase.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from freezegun import freeze_time
 
-from components.usecase import RecordType, _get_working_date, record_time, register_user
+from components.usecase import RecordType, _get_working_date, record_time, register_user, get_daily_timacard_data
 
 
 class TestUseCase(unittest.TestCase):
@@ -77,3 +77,25 @@ class TestUseCase(unittest.TestCase):
             with self.subTest(msg=f"current_time={current_time}, working_date={working_date}"):
                 with freeze_time(current_time):
                     self.assertEqual(_get_working_date(), working_date)
+
+    @mock.patch("components.requester.KOTRequester.get")
+    def test_get_daily_timacard_data(self, mocked_get):
+        # モックのレスポンスを設定
+        expected_response = {"data": "dummy-data"}
+        mocked_get.return_value = expected_response
+        
+        # パラメータ設定
+        from_date = "2025-06-01"
+        to_date = "2025-06-30"
+        
+        # 関数実行
+        result = get_daily_timacard_data(from_date=from_date, to_date=to_date)
+        
+        # 検証
+        self.assertEqual(mocked_get.call_count, 1)
+        self.assertEqual(result, expected_response)
+        
+        # 引数の検証
+        mocked_get_args, _ = mocked_get.call_args
+        expected_uri = f"/daily-workings?&start={from_date}&end={to_date}&additionalFields=currentDateEmployee"
+        self.assertEqual(mocked_get_args[0], expected_uri)

--- a/test/components/test_usecase.py
+++ b/test/components/test_usecase.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from freezegun import freeze_time
 
-from components.usecase import RecordType, _get_working_date, record_time, register_user, get_daily_timacard_data
+from components.usecase import RecordType, _get_working_date, get_daily_timacard_data, record_time, register_user
 
 
 class TestUseCase(unittest.TestCase):

--- a/test/components/test_usecase.py
+++ b/test/components/test_usecase.py
@@ -83,18 +83,18 @@ class TestUseCase(unittest.TestCase):
         # モックのレスポンスを設定
         expected_response = {"data": "dummy-data"}
         mocked_get.return_value = expected_response
-        
+
         # パラメータ設定
         from_date = "2025-06-01"
         to_date = "2025-06-30"
-        
+
         # 関数実行
         result = get_daily_timacard_data(from_date=from_date, to_date=to_date)
-        
+
         # 検証
         self.assertEqual(mocked_get.call_count, 1)
         self.assertEqual(result, expected_response)
-        
+
         # 引数の検証
         mocked_get_args, _ = mocked_get.call_args
         expected_uri = f"/daily-workings?&start={from_date}&end={to_date}&additionalFields=currentDateEmployee"

--- a/test/handler/jp/test_timecard_check.py
+++ b/test/handler/jp/test_timecard_check.py
@@ -1,0 +1,154 @@
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+from components.requester import KOTException
+from components.typing import SlackRequest
+from handler.jp.timecard_check import announce_timecard_errors
+
+
+class TestTimecardCheck(unittest.TestCase):
+    @mock.patch("handler.jp.timecard_check.get_daily_timacard_data")
+    def test_announce_timecard_errors__success_with_errors(self, mocked_get_daily_timacard_data):
+        # 勤怠エラーがある場合のモックデータを準備
+        mocked_get_daily_timacard_data.return_value = [
+            {
+                "date": "2023-04-01",
+                "dailyWorkings": [
+                    {
+                        "isError": True,
+                        "currentDateEmployee": {
+                            "code": "0009",
+                            "lastName": "山田",
+                            "firstName": "伝蔵"
+                        }
+                    },
+                    {
+                        "isError": True,
+                        "currentDateEmployee": {
+                            "code": "0010",
+                            "lastName": "熊本",
+                            "firstName": "太郎"
+                        }
+                    }
+                ]
+            },
+            {
+                "date": "2023-04-02",
+                "dailyWorkings": [
+                    {
+                        "isError": True,
+                        "currentDateEmployee": {
+                            "code": "0100",
+                            "lastName": "らぷ",
+                            "firstName": "らす"
+                        }
+                    },
+                    {
+                        # 唯一勤怠エラーではない
+                        "isError": False,
+                        "currentDateEmployee": {
+                            "code": "0200",
+                            "lastName": "テスト",
+                            "firstName": "ユーザー"
+                        }
+                    }
+                ]
+            }
+        ]
+
+        say = MagicMock()
+        request = SlackRequest(channel_id="dummy-channel-id", user_id="dummy-user-id", text="dummy-text")
+
+        announce_timecard_errors(say=say, request=request)
+
+        self.assertEqual(mocked_get_daily_timacard_data.call_count, 1)
+        self.assertEqual(say.call_count, 1)
+        
+        say_call_args, _ = say.call_args
+        message = say_call_args[0]
+        
+        # 基本的なメッセージ内容の確認
+        self.assertIn("勤怠エラーがある人をお知らせするよ", message)
+        self.assertIn("■2023-04-01", message)
+        self.assertIn("0009 山田 伝蔵", message)
+        self.assertIn("0010 熊本 太郎", message)
+        self.assertIn("■2023-04-02", message)
+        self.assertIn("0100 らぷ らす", message)
+        
+        # エラーがない人は表示されていないことを確認
+        self.assertNotIn("0200 テスト ユーザー", message)
+
+    @mock.patch("handler.jp.timecard_check.get_daily_timacard_data")
+    def test_announce_timecard_errors__success_no_errors(self, mocked_get_daily_timacard_data):
+        # 勤怠エラーがない場合のモックデータを準備
+        mocked_get_daily_timacard_data.return_value = [
+            {
+                "date": "2023-04-01",
+                "dailyWorkings": [
+                    {
+                        "isError": False,
+                        "currentDateEmployee": {
+                            "code": "0009",
+                            "lastName": "山田",
+                            "firstName": "伝蔵"
+                        }
+                    }
+                ]
+            }
+        ]
+
+        say = MagicMock()
+        request = SlackRequest(channel_id="dummy-channel-id", user_id="dummy-user-id", text="dummy-text")
+
+        announce_timecard_errors(say=say, request=request)
+
+        self.assertEqual(mocked_get_daily_timacard_data.call_count, 1)
+        self.assertEqual(say.call_count, 1)
+        
+        say_call_args, _ = say.call_args
+        message = say_call_args[0]
+        
+        # エラーがない場合のメッセージ内容の確認
+        self.assertIn("勤怠エラーの人はいないよ！やったね！", message)
+
+    @mock.patch("handler.jp.timecard_check.get_daily_timacard_data")
+    def test_announce_timecard_errors__no_data(self, mocked_get_daily_timacard_data):
+        # データが空の場合
+        mocked_get_daily_timacard_data.return_value = []
+
+        say = MagicMock()
+        request = SlackRequest(channel_id="dummy-channel-id", user_id="dummy-user-id", text="dummy-text")
+
+        announce_timecard_errors(say=say, request=request)
+
+        self.assertEqual(mocked_get_daily_timacard_data.call_count, 1)
+        self.assertEqual(say.call_count, 1)
+        
+        say_call_args, _ = say.call_args
+        message = say_call_args[0]
+        
+        # データがない場合のメッセージ内容の確認
+        self.assertIn("勤怠データが見つからなかったよ", message)
+
+    @mock.patch("handler.jp.timecard_check.response_kot_error")
+    @mock.patch("handler.jp.timecard_check.get_daily_timacard_data", side_effect=KOTException)
+    def test_announce_timecard_errors__kot_error(self, mocked_get_daily_timacard_data, mocked_response_kot_error):
+        say = MagicMock()
+        request = SlackRequest(channel_id="dummy-channel-id", user_id="dummy-user-id", text="dummy-text")
+
+        announce_timecard_errors(say=say, request=request)
+
+        self.assertEqual(mocked_get_daily_timacard_data.call_count, 1)
+        self.assertEqual(mocked_response_kot_error.call_count, 1)
+
+    @mock.patch("handler.jp.timecard_check.response_general_error")
+    @mock.patch("handler.jp.timecard_check.get_daily_timacard_data", side_effect=Exception)
+    def test_announce_timecard_errors__general_error(self, mocked_get_daily_timacard_data, mocked_response_general_error):
+        say = MagicMock()
+        request = SlackRequest(channel_id="dummy-channel-id", user_id="dummy-user-id", text="dummy-text")
+
+        announce_timecard_errors(say=say, request=request)
+
+        self.assertEqual(mocked_get_daily_timacard_data.call_count, 1)
+        self.assertEqual(mocked_response_general_error.call_count, 1) 

--- a/test/handler/jp/test_timecard_check.py
+++ b/test/handler/jp/test_timecard_check.py
@@ -15,46 +15,21 @@ class TestTimecardCheck(unittest.TestCase):
             {
                 "date": "2023-04-01",
                 "dailyWorkings": [
-                    {
-                        "isError": True,
-                        "currentDateEmployee": {
-                            "code": "0009",
-                            "lastName": "山田",
-                            "firstName": "伝蔵"
-                        }
-                    },
-                    {
-                        "isError": True,
-                        "currentDateEmployee": {
-                            "code": "0010",
-                            "lastName": "熊本",
-                            "firstName": "太郎"
-                        }
-                    }
-                ]
+                    {"isError": True, "currentDateEmployee": {"code": "0009", "lastName": "山田", "firstName": "伝蔵"}},
+                    {"isError": True, "currentDateEmployee": {"code": "0010", "lastName": "熊本", "firstName": "太郎"}},
+                ],
             },
             {
                 "date": "2023-04-02",
                 "dailyWorkings": [
-                    {
-                        "isError": True,
-                        "currentDateEmployee": {
-                            "code": "0100",
-                            "lastName": "らぷ",
-                            "firstName": "らす"
-                        }
-                    },
+                    {"isError": True, "currentDateEmployee": {"code": "0100", "lastName": "らぷ", "firstName": "らす"}},
                     {
                         # 唯一勤怠エラーではない
                         "isError": False,
-                        "currentDateEmployee": {
-                            "code": "0200",
-                            "lastName": "テスト",
-                            "firstName": "ユーザー"
-                        }
-                    }
-                ]
-            }
+                        "currentDateEmployee": {"code": "0200", "lastName": "テスト", "firstName": "ユーザー"},
+                    },
+                ],
+            },
         ]
 
         say = MagicMock()
@@ -64,10 +39,10 @@ class TestTimecardCheck(unittest.TestCase):
 
         self.assertEqual(mocked_get_daily_timacard_data.call_count, 1)
         self.assertEqual(say.call_count, 1)
-        
+
         say_call_args, _ = say.call_args
         message = say_call_args[0]
-        
+
         # 基本的なメッセージ内容の確認
         self.assertIn("勤怠エラーがある人をお知らせするよ", message)
         self.assertIn("■2023-04-01", message)
@@ -75,7 +50,7 @@ class TestTimecardCheck(unittest.TestCase):
         self.assertIn("0010 熊本 太郎", message)
         self.assertIn("■2023-04-02", message)
         self.assertIn("0100 らぷ らす", message)
-        
+
         # エラーがない人は表示されていないことを確認
         self.assertNotIn("0200 テスト ユーザー", message)
 
@@ -86,15 +61,8 @@ class TestTimecardCheck(unittest.TestCase):
             {
                 "date": "2023-04-01",
                 "dailyWorkings": [
-                    {
-                        "isError": False,
-                        "currentDateEmployee": {
-                            "code": "0009",
-                            "lastName": "山田",
-                            "firstName": "伝蔵"
-                        }
-                    }
-                ]
+                    {"isError": False, "currentDateEmployee": {"code": "0009", "lastName": "山田", "firstName": "伝蔵"}}
+                ],
             }
         ]
 
@@ -105,10 +73,10 @@ class TestTimecardCheck(unittest.TestCase):
 
         self.assertEqual(mocked_get_daily_timacard_data.call_count, 1)
         self.assertEqual(say.call_count, 1)
-        
+
         say_call_args, _ = say.call_args
         message = say_call_args[0]
-        
+
         # エラーがない場合のメッセージ内容の確認
         self.assertIn("勤怠エラーの人はいないよ！やったね！", message)
 
@@ -124,10 +92,10 @@ class TestTimecardCheck(unittest.TestCase):
 
         self.assertEqual(mocked_get_daily_timacard_data.call_count, 1)
         self.assertEqual(say.call_count, 1)
-        
+
         say_call_args, _ = say.call_args
         message = say_call_args[0]
-        
+
         # データがない場合のメッセージ内容の確認
         self.assertIn("勤怠データが見つからなかったよ", message)
 
@@ -144,11 +112,13 @@ class TestTimecardCheck(unittest.TestCase):
 
     @mock.patch("handler.jp.timecard_check.response_general_error")
     @mock.patch("handler.jp.timecard_check.get_daily_timacard_data", side_effect=Exception)
-    def test_announce_timecard_errors__general_error(self, mocked_get_daily_timacard_data, mocked_response_general_error):
+    def test_announce_timecard_errors__general_error(
+        self, mocked_get_daily_timacard_data, mocked_response_general_error
+    ):
         say = MagicMock()
         request = SlackRequest(channel_id="dummy-channel-id", user_id="dummy-user-id", text="dummy-text")
 
         announce_timecard_errors(say=say, request=request)
 
         self.assertEqual(mocked_get_daily_timacard_data.call_count, 1)
-        self.assertEqual(mocked_response_general_error.call_count, 1) 
+        self.assertEqual(mocked_response_general_error.call_count, 1)


### PR DESCRIPTION
ref : https://app.holaspirit.com/o/5ca435d054548008ed758c72/projects#task-67ae9fffed25c75d6706e2ac

勤怠エラーチェックを自動化するために勤怠ぱっちょに機能を追加
仕様はこれで大丈夫かojimaさんに確認中だが、機能自体を実際に入れておいて害はないのでそのまま入れてしまう
希望があればあとから修正

https://lapras-inc.slack.com/archives/CNNESDZV1/p1741159255397029